### PR TITLE
Add watch camera follow

### DIFF
--- a/Assets/Prefabs/PlayerCamera/CameraRegionFixed.cs
+++ b/Assets/Prefabs/PlayerCamera/CameraRegionFixed.cs
@@ -1,7 +1,7 @@
 using UnityEngine;
 
 /**
- * 
+ * On player enter, switches the camera to the Fixed Follow.
  */
 public class CameraRegionFixed : MonoBehaviour
 {

--- a/Assets/Prefabs/PlayerCamera/CameraRegionWatch.cs
+++ b/Assets/Prefabs/PlayerCamera/CameraRegionWatch.cs
@@ -1,22 +1,18 @@
 using UnityEngine;
 
 /**
- * On player enter, the camera follows the player on a rail.
+ * On player enter, the camera follows the player from some offset away.
  */
-public class CameraRegionRail : MonoBehaviour
+public class CameraRegionWatch : MonoBehaviour
 {
     /**
      * Starting position of the camera. Set to some empty child.
      */
-    public Transform perspective;
-    /**
-     * Rail vector/direction of the camera. This camera will only move in this direction.
-     */
-    public Vector3 rail;
+    public Vector3 offset;
     /**
      * Glide speed, every frame this the origin and destination camera are Lerp'd with this value.
      */
-    public float speed = 0.01f;
+    public float speed = 0.1f;
     
     private void OnTriggerEnter(Collider other)
     {
@@ -34,6 +30,6 @@ public class CameraRegionRail : MonoBehaviour
             return;
         }
         
-        manager.SwitchFollow(this, new CameraFollowRail(perspective.position, perspective.forward, rail, speed));
+        manager.SwitchFollow(this, new CameraFollowWatch(offset, speed));
     }
 }

--- a/Assets/Prefabs/PlayerCamera/CameraRegionWatch.cs.meta
+++ b/Assets/Prefabs/PlayerCamera/CameraRegionWatch.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 7c18afcc6ded479fa5ec22589fc8ff62
+timeCreated: 1707949334

--- a/Assets/Scenes/Desert.unity
+++ b/Assets/Scenes/Desert.unity
@@ -1342,6 +1342,74 @@ MeshCollider:
   m_Convex: 0
   m_CookingOptions: 30
   m_Mesh: {fileID: -8678823145569952518, guid: c3bf8a0d45fa34b769c858087af285dd, type: 3}
+--- !u!1 &1424546634
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1424546637}
+  - component: {fileID: 1424546636}
+  - component: {fileID: 1424546635}
+  m_Layer: 8
+  m_Name: CactusRegion
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1424546635
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1424546634}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7c18afcc6ded479fa5ec22589fc8ff62, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  offset: {x: 3, y: 4, z: 1}
+  speed: 0.01
+--- !u!65 &1424546636
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1424546634}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 14.34491, y: 4.875138, z: 22.19331}
+  m_Center: {x: 4.798231, y: 0.33750987, z: 6.930952}
+--- !u!4 &1424546637
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1424546634}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 25.26, y: -2.8, z: -11.45}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1459890633 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 5252682845850649624, guid: c3bf8a0d45fa34b769c858087af285dd,
@@ -1971,3 +2039,4 @@ SceneRoots:
   - {fileID: 1679953587}
   - {fileID: 94889275}
   - {fileID: 104111397}
+  - {fileID: 1424546637}

--- a/Assets/Scenes/Desert.unity
+++ b/Assets/Scenes/Desert.unity
@@ -1373,7 +1373,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   offset: {x: 3, y: 4, z: 1}
-  speed: 0.01
+  speed: 0.015
 --- !u!65 &1424546636
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -1490,8 +1490,8 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1645706454}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -12.7, y: 6.96, z: -22.35}
+  m_LocalRotation: {x: 0.18948981, y: -0.81008977, z: 0.37672094, w: 0.4073445}
+  m_LocalPosition: {x: 35.11979, y: 2.5551705, z: 5.0512605}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/Assets/Scripts/CameraFollow/CameraFollowWatch.cs
+++ b/Assets/Scripts/CameraFollow/CameraFollowWatch.cs
@@ -1,0 +1,29 @@
+using UnityEngine;
+
+public class CameraFollowWatch : ICameraFollow
+{
+    private readonly Vector3 _offset;
+    private readonly float _speed;
+    
+    public CameraFollowWatch(Vector3 offset, float speed)
+    {
+        _offset = offset;
+        _speed = speed;
+    }
+    
+    public CameraPosition FollowPosition(CameraFollowContext context)
+    {
+        if (context.Follow == null)
+        {
+            return context.Current;
+        }
+
+        var expected = context.Follow.Value + _offset;
+
+        return new CameraPosition
+        {
+            Position = Vector3.Lerp(context.Current.Position, expected, _speed),
+            Forward = (-_offset).normalized
+        };
+    }
+}

--- a/Assets/Scripts/CameraFollow/CameraFollowWatch.cs.meta
+++ b/Assets/Scripts/CameraFollow/CameraFollowWatch.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 8f706fe78c904109afbbb2d083f1818e
+timeCreated: 1707949025

--- a/Assets/Scripts/CameraFollow/ICameraFollow.cs
+++ b/Assets/Scripts/CameraFollow/ICameraFollow.cs
@@ -5,7 +5,7 @@ public struct CameraPosition
     public Vector3 Position;
     public Vector3 Forward;
 
-    public static CameraPosition Zero = new CameraPosition
+    public static CameraPosition Zero = new()
     {
         Position = Vector3.zero,
         Forward = Vector3.forward


### PR DESCRIPTION
There already exists a follow that watches a player from a fixed vantage point and watches a player on a rail.
I've added a camera follow that watches a player from an offset called the `CameraFollowWatch`.